### PR TITLE
Removed unnecessary rules.

### DIFF
--- a/simple-grid.scss
+++ b/simple-grid.scss
@@ -59,18 +59,12 @@ $gutter:            20px;
 
 .row {
   @extend .clearfix;
-  clear: both;
   margin-left: -$gutter;
 }
 
 .col {
   float: left;
   padding-left: $gutter;
-  margin-bottom: $gutter;
-  .row {
-    margin-top: $gutter;
-  }
-}
 
 
 


### PR DESCRIPTION
`.row` doesn't need `clear: both` as it extends `.clearfix`

Also removed `margin-top` and `margin-bottom` from some elements, vertical spacing should be done by the author and not the grid framework IMO
